### PR TITLE
Removing extraneous `require('utils')`

### DIFF
--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -977,7 +977,6 @@ function factory (type, config, load, typed, math) {
             }
           }
         }
-        var util = require('util');
 
         // Is the proposed unit list "simpler" than the existing one?
         if(proposedUnitList.length < this.units.length && !missingBaseDim) {


### PR DESCRIPTION
When packaging this library with `rollup.js` - there is a continual complaint about importing a "node built-in" `util`, which stems from this line in `Unit.js`. The line appears extraneous, however - so this PR simply removes it.